### PR TITLE
Free mouse capture on exception

### DIFF
--- a/Code/reverse/include/Debug.hpp
+++ b/Code/reverse/include/Debug.hpp
@@ -7,6 +7,6 @@ namespace TiltedPhoques
         static void WaitForDebugger() noexcept;
         static void CreateConsole() noexcept;
         static void OnAttach() noexcept;
-        static void OnDettach() noexcept;
+        static void OnDetach() noexcept;
     };
 }

--- a/Code/reverse/src/Debug.cpp
+++ b/Code/reverse/src/Debug.cpp
@@ -29,9 +29,10 @@ namespace TiltedPhoques
 
     LONG WINAPI OnException(PEXCEPTION_POINTERS apExceptionInfo)
     {
-        ReleaseCapture(); // Release Skyrim's mouse capture - best effort
+        // Release Skyrim's mouse capture - best effort
+        ReleaseCapture();
 
-        // Perhaps EXCEPTION_EXECUTE_HANDLER is more in order, in case someone after us handles the exception graceully?
+        // Perhaps EXCEPTION_EXECUTE_HANDLER is more in order, in case someone after us handles the exception gracefully?
         return EXCEPTION_CONTINUE_SEARCH;
 
         UNREFERENCED_PARAMETER(apExceptionInfo);
@@ -46,7 +47,7 @@ namespace TiltedPhoques
         assert(s_pVectoredHandler != NULL);
     }
 
-    void Debug::OnDettach() noexcept
+    void Debug::OnDetach() noexcept
     {
         if (s_pVectoredHandler)
         {


### PR DESCRIPTION
I'm trying to debug a crash-on-start, but currently when an exception occurs, Skyrim keeps the mouse capture and doesn't let me interact with the system until I close this.
This adds a VEH handler which releases the mouse upon exception.
If another intentional VEH handler will be added at some point later, this might require some fiddling so the mouse won't randomly lose focus.