### PR TITLE
Expose a function that is part of TP_HOOK_IAT()

### DIFF
--- a/Code/reverse/include/FunctionHook.hpp
+++ b/Code/reverse/include/FunctionHook.hpp
@@ -7,6 +7,8 @@
 
 namespace TiltedPhoques
 {
+    void** GetImportedFunction(const wchar_t* acpModuleName, const char* acpLibraryName, const char* acpMethod) noexcept;
+
     struct FunctionHook
     {
         FunctionHook() noexcept;

--- a/Code/reverse/src/FunctionHook.cpp
+++ b/Code/reverse/src/FunctionHook.cpp
@@ -9,8 +9,6 @@
 
 namespace TiltedPhoques
 {
-    static void** GetImportedFunction(const wchar_t *acpModuleName, const char* acpLibraryName, const char* acpMethod) noexcept;
-
     FunctionHook::FunctionHook() noexcept
         : m_ppDetourFunction(nullptr)
         , m_pSystemFunction(nullptr)
@@ -117,7 +115,7 @@ namespace TiltedPhoques
         return pRealFunction;
     }
 
-    static void** GetImportedFunction(const wchar_t *acpModuleName, const char* acpLibraryName, const char* acpMethod) noexcept
+    void** GetImportedFunction(const wchar_t *acpModuleName, const char* acpLibraryName, const char* acpMethod) noexcept
     {
         const auto pBase = GetModuleHandleW(acpModuleName);
 


### PR DESCRIPTION
Because it is useful in solving an issue with immersive_launcher\loader\ExeLoader.cpp and smashed IAT hooks.

This is a prerequisite for the SSE Engine Fixes v7 support PR coming up. Better initialization of the preloader; have to preserve an IAT hook overwritten in the exe loader.