### PR TITLE
Remove TiltedCore version pin

### DIFF
--- a/xmake.lua
+++ b/xmake.lua
@@ -5,7 +5,7 @@ set_xmakever("2.6.0")
 
 -- direct dependency version pinning
 add_requires(
-    "tiltedcore v0.2.7", 
+    "tiltedcore", 
     "hopscotch-map v2.3.1", 
     "minhook v1.3.3", 
     "catch2 2.13.9", 


### PR DESCRIPTION
Submodules inherit pins from their parent, so it is counter-productive to have pins in them.